### PR TITLE
Fix: make color_enabled consistent

### DIFF
--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -72,7 +72,7 @@ module RSpec
 
           # Patch so it does not apply a color if code_or_symbol is nil
           def wrap(text, code_or_symbol)
-            if RSpec.configuration.color_enabled? && code = console_code_for(code_or_symbol)
+            if SuperDiff.configuration.color_enabled? && code = console_code_for(code_or_symbol)
               "\e[#{code}m#{text}\e[0m"
             else
               text

--- a/support/test_plan.rb
+++ b/support/test_plan.rb
@@ -154,10 +154,6 @@ class TestPlan
       option_parser.parse!
     end
 
-    RSpec.configure do |config|
-      config.color_mode = color_enabled? ? :on : :off
-    end
-
     SuperDiff.configuration.merge!(
       configuration.merge(color_enabled: color_enabled?)
     )


### PR DESCRIPTION
Fixes the bug where disabling color only applied to the diff, not the header and the key. Disabling color is needed when using CircleCI which can show color sometimes, and remove it at other times (I believe based on the length of the log). And in the later case, we're seeing ansi color codes.