### PR TITLE
Fix recursion hang

### DIFF
--- a/lib/super_diff/recursion_guard.rb
+++ b/lib/super_diff/recursion_guard.rb
@@ -7,7 +7,7 @@ module SuperDiff
     RECURSION_GUARD_COUNTER_KEY = "super_diff_recursion_guard_counter".freeze
 
     def self.guarding_recursion_of(*objects, &block)
-      # recursion_counter is being added as a crude fix to the problem described in
+      # This recursion counter is being added as a crude fix to the problem described in
       # https://github.com/mcmire/super_diff/issues/160
       # If that issue receives a more elegant solution, this can be removed from
       # the Tidelift version of the code.
@@ -15,6 +15,7 @@ module SuperDiff
       Thread.current[RECURSION_GUARD_COUNTER_KEY] = Thread.current[
         RECURSION_GUARD_COUNTER_KEY
       ] + 1
+      pp "recursion counter: #{Thread.current[RECURSION_GUARD_COUNTER_KEY]}"
 
       already_seen_objects, first_seen_objects =
         objects.partition do |object|

--- a/lib/super_diff/recursion_guard.rb
+++ b/lib/super_diff/recursion_guard.rb
@@ -4,22 +4,23 @@ module SuperDiff
   module RecursionGuard
     RECURSION_GUARD_KEY = "super_diff_recursion_guard_key".freeze
     PLACEHOLDER = "∙∙∙".freeze
+    RECURSION_GUARD_COUNTER_KEY = "super_diff_recursion_guard_counter".freeze
 
     def self.guarding_recursion_of(*objects, &block)
       # recursion_counter is being added as a crude fix to the problem described in
       # https://github.com/mcmire/super_diff/issues/160
       # If that issue receives a more elegant solution, this can be removed from
       # the Tidelift version of the code.
-      Thread.current["recursion_counter"] ||= 0
-      Thread.current["recursion_counter"] = Thread.current[
-        "recursion_counter"
+      Thread.current[RECURSION_GUARD_COUNTER_KEY] ||= 0
+      Thread.current[RECURSION_GUARD_COUNTER_KEY] = Thread.current[
+        RECURSION_GUARD_COUNTER_KEY
       ] + 1
 
       already_seen_objects, first_seen_objects =
         objects.partition do |object|
           !SuperDiff.primitive?(object) &&
             (
-              Thread.current["recursion_counter"] > 1000 ||
+              Thread.current[RECURSION_GUARD_COUNTER_KEY] > 1000 ||
                 already_seen?(object)
             )
         end

--- a/lib/super_diff/recursion_guard.rb
+++ b/lib/super_diff/recursion_guard.rb
@@ -5,23 +5,25 @@ module SuperDiff
     RECURSION_GUARD_KEY = "super_diff_recursion_guard_key".freeze
     PLACEHOLDER = "∙∙∙".freeze
     RECURSION_GUARD_COUNTER_KEY = "super_diff_recursion_guard_counter".freeze
+    RECURSION_GUARD_COUNTER_MAX_OBJECTS_SEEN = 1000
 
     def self.guarding_recursion_of(*objects, &block)
       # This recursion counter is being added as a crude fix to the problem described in
       # https://github.com/mcmire/super_diff/issues/160
       # If that issue receives a more elegant solution, this can be removed from
       # the Tidelift version of the code.
+      # Note: This is counting total objects seen, not necessarily recursed
       Thread.current[RECURSION_GUARD_COUNTER_KEY] ||= 0
       Thread.current[RECURSION_GUARD_COUNTER_KEY] = Thread.current[
         RECURSION_GUARD_COUNTER_KEY
       ] + 1
-      pp "recursion counter: #{Thread.current[RECURSION_GUARD_COUNTER_KEY]}"
 
       already_seen_objects, first_seen_objects =
         objects.partition do |object|
           !SuperDiff.primitive?(object) &&
             (
-              Thread.current[RECURSION_GUARD_COUNTER_KEY] > 1000 ||
+              Thread.current[RECURSION_GUARD_COUNTER_KEY] >
+                RECURSION_GUARD_COUNTER_MAX_OBJECTS_SEEN ||
                 already_seen?(object)
             )
         end

--- a/lib/super_diff/recursion_guard.rb
+++ b/lib/super_diff/recursion_guard.rb
@@ -6,9 +6,22 @@ module SuperDiff
     PLACEHOLDER = "∙∙∙".freeze
 
     def self.guarding_recursion_of(*objects, &block)
+      # recursion_counter is being added as a crude fix to the problem described in
+      # https://github.com/mcmire/super_diff/issues/160
+      # If that issue receives a more elegant solution, this can be removed from
+      # the Tidelift version of the code.
+      Thread.current["recursion_counter"] ||= 0
+      Thread.current["recursion_counter"] = Thread.current[
+        "recursion_counter"
+      ] + 1
+
       already_seen_objects, first_seen_objects =
         objects.partition do |object|
-          !SuperDiff.primitive?(object) && already_seen?(object)
+          !SuperDiff.primitive?(object) &&
+            (
+              Thread.current["recursion_counter"] > 1000 ||
+                already_seen?(object)
+            )
         end
 
       first_seen_objects.each do |object|

--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -21,6 +21,9 @@ module RSpec
     module ExpectationHelper
       SuperDiff.insert_singleton_overrides(self) do
         def handle_failure(matcher, message, failure_message_method)
+          Thread.current[
+            SuperDiff::RecursionGuard::RECURSION_GUARD_COUNTER_KEY
+          ] = 0
           message = message.call if message.respond_to?(:call)
           message ||= matcher.__send__(failure_message_method)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,8 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 
   config.color_mode = :on if ENV["CI"] == "true"
+
+  config.before { Thread.current["recursion_counter"] = 0 }
 end
 
 require "warnings_logger"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,9 @@ RSpec.configure do |config|
 
   config.color_mode = :on if ENV["CI"] == "true"
 
-  config.before { Thread.current["recursion_counter"] = 0 }
+  config.before do
+    Thread.current[SuperDiff::RecursionGuard::RECURSION_GUARD_COUNTER_KEY] = 0
+  end
 end
 
 require "warnings_logger"


### PR DESCRIPTION
Hacky (but functional) fix for the recursion hang when super_diff attempts to serialize the diff for request objects.